### PR TITLE
Fix comparison check by removing dashes.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,7 +29,7 @@ bash 'build_ruby' do
   make install
   rm -rf ruby-#{node['ruby']['version']}
   EOS
-  not_if '[[ $(ruby -v) == *#{node["ruby"]["version"]}* ]]'
+  not_if '[[ $(/usr/local/bin/ruby -v) == *#{node["ruby"]["version"].gsub('-','')}* ]]'
 end
 
 node['ruby']['gems'].each do |gem_name|

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,7 +29,7 @@ bash 'build_ruby' do
   make install
   rm -rf ruby-#{node['ruby']['version']}
   EOS
-  not_if '[[ $(/usr/local/bin/ruby -v) == *#{node["ruby"]["version"].gsub('-','')}* ]]'
+  not_if %Q!bash -c '[[ $(/usr/local/bin/ruby -v) == *#{node['ruby']['version'].gsub('-','')}* ]]'!
 end
 
 node['ruby']['gems'].each do |gem_name|


### PR DESCRIPTION
I also specified "run /usr/local/bin/ruby", because ./configure will
default to a prefix of "/usr/local ".  Adding "/usr/local/bin" may be
wholly unnecessary, but I have yet to win a victory with Chef today so
I'm using it.
